### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/deleted.php
+++ b/syntax/deleted.php
@@ -50,7 +50,7 @@ class syntax_plugin_changemarks_deleted extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($state) {
 
             // entry pattern with optional title
@@ -77,7 +77,7 @@ class syntax_plugin_changemarks_deleted extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if (($mode == 'xhtml') && (is_array($data))) {
             switch ($data[0]) {
                 case DOKU_LEXER_ENTER:

--- a/syntax/highlighted.php
+++ b/syntax/highlighted.php
@@ -48,7 +48,7 @@ class syntax_plugin_changemarks_highlighted extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($state) {
 
             // entry pattern with optional title
@@ -74,7 +74,7 @@ class syntax_plugin_changemarks_highlighted extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if (($mode == 'xhtml') && (is_array($data))) {
             switch ($data[0]) {
                 case DOKU_LEXER_ENTER:

--- a/syntax/inserted.php
+++ b/syntax/inserted.php
@@ -50,7 +50,7 @@ class syntax_plugin_changemarks_inserted extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($state) {
 
             // entry pattern with optional title
@@ -77,7 +77,7 @@ class syntax_plugin_changemarks_inserted extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if (($mode == 'xhtml') && (is_array($data))) {
             switch ($data[0]) {
                 case DOKU_LEXER_ENTER:


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.